### PR TITLE
fix(cicd): be more specific with service config for the api

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,30 +12,46 @@ jobs:
       IMAGE_NAME: apiflair
       PROJECT_ID: netcarbon-datawarehouse
       SERVICE: api-flair
-      IMAGE_LOCATION : landcover
+      IMAGE_LOCATION: landcover
+      SERVICE_ACCOUNT_MAIL: compte cicd-landcover@netcarbon-datawarehouse.iam.gserviceaccount.com
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - uses: google-github-actions/setup-gcloud@v0
-      with:
-        service_account_key: ${{ secrets.SERVICE_ACCOUNT_KEY }}
-        project_id: ${{ env.PROJECT_ID }}
-        export_default_credentials: true
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+          project_id: ${{ env.PROJECT_ID }}
+          export_default_credentials: true
 
-    - name: Build Docker Image
-      run: docker build -t $IMAGE_NAME:latest .
+      - name: Build Docker Image
+        run: docker build -t $IMAGE_NAME:latest .
 
-    - name: Configure Docker Client
-      run: |-
-        gcloud auth configure-docker --quiet
-        gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
+      - name: Configure Docker Client
+        run: |-
+          gcloud auth configure-docker --quiet
+          gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 
-    - name: Push Docker Image to Artifact Registry
-      run: |-
-        docker tag $IMAGE_NAME:latest europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest
-        docker push europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest
+      - name: Push Docker Image to Artifact Registry
+        run: |-
+          docker tag $IMAGE_NAME:latest europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest
+          docker push europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest
 
-    - name: Deploy Image to Cloud Run
-      run: gcloud run deploy $SERVICE --image europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest --region europe-west4 --allow-unauthenticated
+      - name: Deploy Image to Cloud Run
+        run: |
+          gcloud run deploy $SERVICE \
+            --image europe-west1-docker.pkg.dev/$PROJECT_ID/$IMAGE_LOCATION/$IMAGE_NAME:latest \
+            --region europe-west4 \
+            --project=netcarbon-datawarehouse \
+            --service-account $SERVICE_ACCOUNT_MAIL \
+            --allow-unauthenticated \
+            --set-env-vars=FLAIR_DETECT_BATCH_SIZE=4,GARBAGE_COLLECTOR_FREQUENCY=10,CLEAN_ALL_FILES_AFTER_PREDICTION=true \
+            --execution-environment=gen2 \
+            --cpu 4 \
+            --memory 16Gi \
+            --timeout 1800 \
+            --concurrency 1 \
+            --min-instances 0 \
+            --max-instances 20 \
+            --cpu-boost


### PR DESCRIPTION
Une partie de la config du service était géré à la main (constantes, timeout, ...)

Note : il faut aussi ajouter les rôles Cloud Run Developer & Service Account User au compte cicd-landcover@netcarbon-datawarehouse.iam.gserviceaccount.com.